### PR TITLE
Fix undefined value on regex;

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,22 +27,25 @@ function regexMatch(input, regex) {
   if (regex == void 0) {
     return null;
   }
+  
+  /** This will fix the error "Cannot supply flags when constructing one RegExp from another" */
+  if (regex) {
+    var regexp = new RegExp(regex, "g");
+    var match = regexp.exec(input);
 
-  var regexp = new RegExp(regex, "g");
-  var match = regexp.exec(input);
+    while (match != null && match[0] != '') {
+      var index, v;
 
-  while (match != null && match[0] != '') {
-    var index, v;
+      if (match.length == 1) {
+        index = 0;
+      } else { index = 1; }
 
-    if (match.length == 1) {
-      index = 0;
-    } else { index = 1; }
-
-    while (index < match.length) {
-      v = match[index];
-      result.push(v)
-      index++;
-    }
+      while (index < match.length) {
+        v = match[index];
+        result.push(v)
+        index++;
+      }
+  }
 
     match = regexp.exec(input);
   }


### PR DESCRIPTION
When the regex value is undefined the "Cannot supply flags when constructing one RegExp from another" will occur. To fix this, just trap the regex value and check if it is not undefined.